### PR TITLE
Added support for ES6 modules (useful for transpiler)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Lightweight templates for [React](http://facebook.github.io/react/index.html).
 * Easy syntax that's similar to HTML, supported by most IDEs.
 * Clear separation of presentation and logic - almost zero HTML in component files.
 * Declarative coding ensures that the HTML that you write and the HTML you inspect look nearly identical.
-* Supports AMD, CommonJS, and globals.
+* Supports AMD, CommonJS, ES6, and globals.
 
 ## How does it work
 React Templates compiles an *.rt file (react template file - an extended HTML format) into a JavaScript file. This file, which uses AMD syntax, returns a function. When invoked, this function returns a virtual React DOM based on React.DOM elements and custom user components. 
@@ -340,6 +340,20 @@ function repeatItem1(item, itemIndex) {
     return React.createElement(MyComp, {}, React.createElement('div', {}, utils.toLower(item.name)));
 }
 module.exports = function () {
+    return _.map(items, repeatItem1.bind(this));
+};
+```
+###### Compiled (with ES6 flag):
+```javascript
+import { React } from 'react/addons';
+import { _ } from 'lodash';
+import { MyComp } from 'comps/myComp';
+import { utils } from 'utils/utils';
+
+function repeatItem1(item, itemIndex) {
+    return React.createElement(MyComp, {}, React.createElement('div', {}, utils.toLower(item.name)));
+}
+export default function () {
     return _.map(items, repeatItem1.bind(this));
 };
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -25,7 +25,7 @@ $ rt <filename>[,<filename>] [<args>]
 Options:
   -h, --help           Show help.
   -c, --color          Use colors in output. - default: true
-  -m, --modules String Use output modules. (amd|commonjs|none) - default: none
+  -m, --modules String Use output modules. (amd|commonjs|es6|none) - default: none
   -r, --force          Force creation of output. skip file check. - default: false
   -f, --format String  Use a specific output format. (stylish|json) - default: stylish
   -t, --target-version String  React version to generate code for (0.12.1, 0.12.0, 0.11.2, 0.11.1, 0.11.0, 0.10.0) - default: 0.12.1

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
                 <li>Easy syntax that's similar to HTML, supported by most IDEs.</li>
                 <li>Clear separation of presentation and logic - almost zero HTML in component files.</li>
                 <li>Declarative coding ensures that the HTML that you write and the HTML you inspect look nearly identical.</li>
-                <li>Supports <a href="#amd">AMD</a>, <a href="#commonjs">CommonJS</a>, and globals.</li>
+                <li>Supports <a href="#amd">AMD</a>, <a href="#commonjs">CommonJS</a>, <a href="#es6">ES6</a>, and globals.</li>
             </ul>
         </section>
         <section id="home-section" class="home-section">

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "chalk": "^0.5.1",
     "cheerio": "^0.18.0",
     "escodegen": "^1.6.1",
-    "esprima": "^2.0.0",
+    "esprima-harmony": "^7001.1.0-dev-harmony-fb",
     "lodash": "^3.1.0",
     "optionator": "^0.5.0",
     "text-table": "^0.2.0"

--- a/src/options.js
+++ b/src/options.js
@@ -45,7 +45,7 @@ module.exports = optionator({
         alias: 'm',
         default: 'none',
         type: 'String',
-        description: 'Use output modules. (amd|commonjs|none)'
+        description: 'Use output modules. (amd|commonjs|es6|none)'
     }, {
         option: 'name',
         alias: 'n',

--- a/src/reactTemplates.js
+++ b/src/reactTemplates.js
@@ -338,7 +338,7 @@ function handleSelfClosingHtmlTags(nodes) {
 function convertTemplateToReact(html, options) {
     var rootNode = cheerio.load(html, {lowerCaseTags: false, lowerCaseAttributeNames: false, xmlMode: true, withStartIndices: true});
     options = _.defaults({}, options, defaultOptions);
-    var defines = {'react/addons': 'React', lodash: '_'};
+    var defines = options.defines ? options.defines : {'react/addons': 'React', lodash: '_'};
     var context = defaultContext(html, options);
     var rootTags = _.filter(rootNode.root()[0].children, {type: 'tag'});
     rootTags = handleSelfClosingHtmlTags(rootTags);

--- a/src/reactTemplates.js
+++ b/src/reactTemplates.js
@@ -338,7 +338,7 @@ function handleSelfClosingHtmlTags(nodes) {
 function convertTemplateToReact(html, options) {
     var rootNode = cheerio.load(html, {lowerCaseTags: false, lowerCaseAttributeNames: false, xmlMode: true, withStartIndices: true});
     options = _.defaults({}, options, defaultOptions);
-    var defines = {}; //{'react/addons': 'React', lodash: '_'};
+    var defines = {'react/addons': 'React', lodash: '_'};
     var context = defaultContext(html, options);
     var rootTags = _.filter(rootNode.root()[0].children, {type: 'tag'});
     rootTags = handleSelfClosingHtmlTags(rootTags);

--- a/src/reactTemplates.js
+++ b/src/reactTemplates.js
@@ -338,7 +338,7 @@ function handleSelfClosingHtmlTags(nodes) {
 function convertTemplateToReact(html, options) {
     var rootNode = cheerio.load(html, {lowerCaseTags: false, lowerCaseAttributeNames: false, xmlMode: true, withStartIndices: true});
     options = _.defaults({}, options, defaultOptions);
-    var defines = {'react/addons': 'React', lodash: '_'};
+    var defines = {}; //{'react/addons': 'React', lodash: '_'};
     var context = defaultContext(html, options);
     var rootTags = _.filter(rootNode.root()[0].children, {type: 'tag'});
     rootTags = handleSelfClosingHtmlTags(rootTags);

--- a/test/data/div.rt.es6.js
+++ b/test/data/div.rt.es6.js
@@ -1,0 +1,5 @@
+import { React } from 'react/addons';
+import { _ } from 'lodash';
+export default function () {
+    return React.createElement('div', {});
+};

--- a/test/src/test.js
+++ b/test/src/test.js
@@ -131,6 +131,7 @@ test('conversion test commonjs', function (t) {
     var files = [
         {source: 'div.rt', expected: 'div.rt.commonjs.js', options: {modules: 'commonjs'}},
         {source: 'div.rt', expected: 'div.rt.amd.js', options: {modules: 'amd', name: 'div'}},
+        {source: 'div.rt', expected: 'div.rt.es6.js', options: {modules: 'es6', name: 'div'}},
         {source: 'div.rt', expected: 'div.rt.globals.js', options: {modules: 'none', name: 'div'}}
     ];
     t.plan(files.length);


### PR DESCRIPTION
Everything works apart from this one strange test, can anybody help me finding the difference between these two string? It's probably some whitespace/newline issue...

```
not ok 28 should be equal
  ---
    operator: equal
    expected:
      "'import { React } from \\'react/addons\\';\\nimport { _ } from \\'lodash\\';\\nexport default function () {\\n    return React.createElement(\\'div\\', {});\\n};'":
    actual:
      "'import { React } from \\'react/addons\\';\\nimport { _ } from \\'lodash\\';\\nexport default function () {\\n    return React.createElement(\\'div\\', {});\\n};'":
    at:       |
      compareAndWrite (/Users/alex/Development/react-templates/test/src/test.js:124:7)
  ...
```