### PR TITLE
Support for TypeScript

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -47,7 +47,7 @@ This option allows to override the output file even if there are no changes.
 
 ### `-m`, `--modules`
 
-Use output modules. (amd|commonjs|none) - default: none
+Use output modules. (amd|commonjs|none|typescript) - default: none
 
 ### `-f`, `--format`
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -58,7 +58,14 @@ function handleSingleFile(currentOptions, filename) {
         return;// only handle html files
     }
     try {
-        api.convertFile(filename, filename + '.js', currentOptions, context);
+        var ext;
+        if (currentOptions.modules !== 'typescript') {
+            ext = '.js';
+        }
+        else {
+            ext='.ts';
+        }
+        api.convertFile(filename, filename + ext, currentOptions, context);
     } catch (e) {
         context.error(e.message, filename, e.line, e.column, e.startOffset, e.endOffset);
     }

--- a/src/options.js
+++ b/src/options.js
@@ -45,7 +45,7 @@ module.exports = optionator({
         alias: 'm',
         default: 'none',
         type: 'String',
-        description: 'Use output modules. (amd|commonjs|none)'
+        description: 'Use output modules. (amd|commonjs|none|typescript)'
     }, {
         option: 'name',
         alias: 'n',

--- a/test/data/div.rt.typescript.ts
+++ b/test/data/div.rt.typescript.ts
@@ -1,0 +1,6 @@
+import React = require('react/addons');
+import _ = require('lodash');
+
+
+var fn = function() { return React.createElement('div',{}) };
+export = fn

--- a/test/src/test.js
+++ b/test/src/test.js
@@ -131,7 +131,8 @@ test('conversion test commonjs', function (t) {
     var files = [
         {source: 'div.rt', expected: 'div.rt.commonjs.js', options: {modules: 'commonjs'}},
         {source: 'div.rt', expected: 'div.rt.amd.js', options: {modules: 'amd', name: 'div'}},
-        {source: 'div.rt', expected: 'div.rt.globals.js', options: {modules: 'none', name: 'div'}}
+        {source: 'div.rt', expected: 'div.rt.globals.js', options: {modules: 'none', name: 'div'}},
+        {source: 'div.rt', expected: 'div.rt.typescript.ts', options: {modules: 'typescript'}}
     ];
     t.plan(files.length);
     files.forEach(check);


### PR DESCRIPTION
Added the `typescript` value to the `--modules` flag to generate TypeScript code from templates.
The generated code can then be directly imported by the `Component` class written in TypeScript.

A demo project of this feature is available at https://github.com/bgrieder/react-templates-typescript-test.

If this is acceptable, the IntelliJ plugin and grunt task should be updated accordingly.