### PR TITLE
Typescript: generate browserify friendly `require` syntax 

### DIFF
--- a/src/reactTemplates.js
+++ b/src/reactTemplates.js
@@ -415,11 +415,11 @@ function convertTemplateToReact(html, options) {
             } else if (tag.children.length) {
                 throw RTCodeError.build('rt-require may have no children', context, tag);
             }
-            //if (options.modules === 'typescript') {
-            //    defines['./' + tag.attribs.dependency] = tag.attribs.as;
-            //} else {
-            defines[tag.attribs.dependency] = tag.attribs.as;
-            //}
+            if (options.modules === 'typescript') {
+                defines['./' + tag.attribs.dependency] = tag.attribs.as;
+            } else {
+                defines[tag.attribs.dependency] = tag.attribs.as;
+            }
         } else if (firstTag === null) {
             firstTag = tag;
         } else {


### PR DESCRIPTION
Typescript: uncommented lines so that `import Local = require('Local')` is actually generated as `import Local = require('./Local')` when `Local.ts` is a module file not residing in `node_modules` . Although this was generating valid Typescript (and CommonJS), it was making browserify choke.

I suspect the same change should be applied to CommonJS generated files.