### PR TITLE
convert es6 imports without brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,10 +349,10 @@ module.exports = function () {
 ```
 ###### Compiled (with ES6 flag):
 ```javascript
-import { React } from 'react/addons';
-import { _ } from 'lodash';
-import { MyComp } from 'comps/myComp';
-import { utils } from 'utils/utils';
+import React from 'react/addons';
+import _ from 'lodash';
+import MyComp from 'comps/myComp';
+import utils from 'utils/utils';
 function repeatItem1(item, itemIndex) {
     return React.createElement(MyComp, {}, React.createElement('div', {}, utils.toLower(item.name)));
 }

--- a/src/reactTemplates.js
+++ b/src/reactTemplates.js
@@ -475,7 +475,7 @@ function convertRT(html, reportContext, options) {
     if (options.modules === 'typescript') {
         vars = _(defines).map(function (reqVar, reqPath) { return 'import ' + reqVar + " = require('" + reqPath + "');"; }).join('\n');
     } else if (options.modules === 'es6') {
-        vars = _(defines).map(function (reqVar, reqPath) { return 'import {' + reqVar + "} from '" + reqPath + "';"; }).join('\n');
+        vars = _(defines).map(function (reqVar, reqPath) { return 'import ' + reqVar + " from '" + reqPath + "';"; }).join('\n');
     } else {
         vars = _(defines).map(function (reqVar, reqPath) { return 'var ' + reqVar + " = require('" + reqPath + "');"; }).join('\n');
     }

--- a/test/data/div.rt.es6.js
+++ b/test/data/div.rt.es6.js
@@ -1,5 +1,5 @@
-import { React } from 'react/addons';
-import { _ } from 'lodash';
+import React from 'react/addons';
+import _ from 'lodash';
 export default function () {
     return React.createElement('div', {});
 };


### PR DESCRIPTION
Don't automatically add brackets to es6 imports.

Converting `<rt-require dependency="./Item" as="Item"/>` to `import {Item} from './Item` prevents importing modules that use `export default` (like React, actually).

Changed to output `import Item from './Item`.

This will resolve #38  .