### PR TITLE
Add CLI options to specify lodash/react import paths

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -91,5 +91,15 @@ module.exports = optionator({
         alias: 'k',
         type: 'Boolean',
         description: 'Show stack trace on errors.'
+    }, {
+        option: 'react-import-path',
+        default: 'react/addons',
+        type: 'String',
+        description: 'Dependency path for importing React.'
+    }, {
+        option: 'lodash-import-path',
+        default: 'lodash',
+        type: 'String',
+        description: 'Dependency path for importing lodash.'
     }]
 });

--- a/src/reactTemplates.js
+++ b/src/reactTemplates.js
@@ -442,8 +442,8 @@ function convertRT(html, reportContext, options) {
     var reactPath = options.reactImportPath || 'react/addons';
     var lodashPath = options.lodashImportPath || 'lodash';
     var defaultDefines = {};
-    defaultDefines[reactPath] = 'react';
-    defaultDefines[lodashPath] = 'lodash';
+    defaultDefines[reactPath] = 'React';
+    defaultDefines[lodashPath] = '_';
 
     var defines = options.defines ? _.clone(options.defines) : defaultDefines;
 

--- a/src/reactTemplates.js
+++ b/src/reactTemplates.js
@@ -438,7 +438,15 @@ function convertTemplateToReact(html, options) {
 function convertRT(html, reportContext, options) {
     var rootNode = cheerio.load(html, {lowerCaseTags: false, lowerCaseAttributeNames: false, xmlMode: true, withStartIndices: true});
     options = _.defaults({}, options, defaultOptions);
-    var defines = options.defines ? _.clone(options.defines) : {'react/addons': 'React', lodash: '_'};
+    
+    var reactPath = options.reactImportPath || 'react/addons';
+    var lodashPath = options.lodashImportPath || 'lodash';
+    var defaultDefines = {};
+    defaultDefines[reactPath] = 'react';
+    defaultDefines[lodashPath] = 'lodash';
+
+    var defines = options.defines ? _.clone(options.defines) : defaultDefines;
+
     var context = defaultContext(html, options);
     validate(options, context, reportContext, rootNode.root()[0]);
     var rootTags = _.filter(rootNode.root()[0].children, {type: 'tag'});


### PR DESCRIPTION
Add in options if user wants to specify different paths to lodash or react in their application.

Right now there is no ability to set the path to React/lodash from the cli, so the default imports will look like:

```
import React from 'react/addons';
import _ from 'lodash';
```

There is the ```defines``` option to specify the all dependencies in an object, but that is undocumented afaik and not useful for people running from the CLI or who want to only set one of the dependencies.

Usage with CommonJS:

```
node bin/rt.js --react-import-path ../vendor/react  --modules commonjs sample/ImageSearch.rt
```

```js
var React = require('../vendor/react');
var _ = require('lodash');
```

With es6:
```
node bin/rt.js --lodash-import-path ../lodash  --modules es6 sample/ImageSearch.rt
```

```js
import React from 'react/addons';
import _ from '../lodash';
```