### PR TITLE
Merge the class and rt-class attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ npm-debug.log
 /target
 /coverage
 
+### Test Output ###
+test/data/*.rt.actual.js

--- a/test/data/rt-class.rt
+++ b/test/data/rt-class.rt
@@ -1,1 +1,5 @@
-<div rt-class="{'a': true, b: false, c: 1, 'd-e': true}"></div>
+<div>
+	<div class="f g-{1+2} h-i" rt-class="{'a': true, b: false, c: 1, 'd-e': true}"></div>
+	Order should not matter
+	<div rt-class="{'a': true, b: false, c: 1, 'd-e': true}" class="f g-{1+2} h-i"></div>
+</div>

--- a/test/data/rt-class.rt.html
+++ b/test/data/rt-class.rt.html
@@ -1,1 +1,1 @@
-<div class="a c d-e"></div>
+<div><div class="f g-3 h-i a c d-e"></div>Order should not matter<div class="a c d-e f g-3 h-i"></div></div>


### PR DESCRIPTION
Hello! I have a number of PRs, and wasn't sure where to put the high level description, so I'll copy and paste it in all of them.

Coming from Angular, I found the react world to be a sad place as far as DSLs go — JSX is a sorry excuse that for some reason beyond me is accepted by the community as the standard. And then I stumbled upon your react-templates work. Thank you!! While converting my work over, I came across a number of wishlist features, and today finally decided to take some time to implement them. They are all aimed at improving readability/writability, as well as sometimes avoiding unnecessary nested elements.

===


Previously an error was raised when a node had both the class and the
rt-class attribute defined. This leads to unnecessary verbose code which
taxes the reader. Splitting static class names from dynamic ones removes
this distraction, and keeps the semantics clean in the reader's mind.

On renaming Props to Attrs. I would have liked to avoid such global
renames on my first commit to somebody else's code base, but I needed to
add a constant for "className", and that seemed like a property on a
React object, as opposed to an attribute on an html element that only
later gets converted to a property. So I took the liberty to rename the
variables.

On tests. Having noticed how order-depenedent some of the code is (in
particular when it comes to dealing with rt-if/rt-repeat/rt-scope), I
decided it might be a good idea to be somewhat black-boxy in the tests,
and ensure that merging of class names works correctly in both
directions.