### PR TITLE
Allow trailing semicolon in rt-scope

### DIFF
--- a/src/reactTemplates.js
+++ b/src/reactTemplates.js
@@ -293,6 +293,8 @@ function convertHtmlToReact(node, context) {
                 data.scopeMapping[boundParam] = boundParam;
             });
             _.each(node.attribs[scopeProp].split(';'), function (scopePart) {
+                if (scopePart.trim().length === 0) return;
+
                 var scopeSubParts = scopePart.split(' as ');
                 if (scopeSubParts.length < 2) {
                     throw RTCodeError.build("invalid scope part '" + scopePart + "'", context, node);

--- a/test/data/scope-trailing-semicolon.rt
+++ b/test/data/scope-trailing-semicolon.rt
@@ -1,0 +1,6 @@
+<div>
+	<div rt-scope="15 as a; 20 as b;">
+		{a + b}
+	</div>
+	<div rt-if="typeof a === 'undefined'">good</div>
+</div>

--- a/test/data/scope-trailing-semicolon.rt.html
+++ b/test/data/scope-trailing-semicolon.rt.html
@@ -1,0 +1,2 @@
+<div><div>35</div><div>good</div></div>
+

--- a/test/src/test.js
+++ b/test/src/test.js
@@ -175,7 +175,7 @@ function normalizeHtml(html) {
 }
 
 test('html tests', function (t) {
-    var files = ['scope.rt', 'lambda.rt', 'eval.rt', 'props.rt', 'custom-element.rt', 'style.rt', 'concat.rt', 'js-in-attr.rt', 'props-class.rt', 'rt-class.rt'];
+    var files = ['scope.rt', 'scope-trailing-semicolon.rt', 'lambda.rt', 'eval.rt', 'props.rt', 'custom-element.rt', 'style.rt', 'concat.rt', 'js-in-attr.rt', 'props-class.rt', 'rt-class.rt'];
     t.plan(files.length);
 
     files.forEach(check);


### PR DESCRIPTION
Hello! I have a number of PRs, and wasn't sure where to put the high level description, so I'll copy and paste it in all of them.

Coming from Angular, I found the react world to be a sad place as far as DSLs go — JSX is a sorry excuse that for some reason beyond me is accepted by the community as the standard. And then I stumbled upon your react-templates work. Thank you!! While converting my work over, I came across a number of wishlist features, and today finally decided to take some time to implement them. They are all aimed at improving readability/writability, as well as sometimes avoiding unnecessary nested elements.

===

Rationale: it is natural for many developers to place a trailing
semicolon after the last scope alias pair, just as they do after every
preceding pair in the list. Since it is possible to save them time (and
perhaps frustration) at no cost in terms of semantics and safety, we
should do so.

On tests. Wasn't sure if this should be broken out into a separate test,
or bundled together with the existing one.