### PR TITLE
Fix package.json to allow build under Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "minor": "npm version minor -m\"update version to %s\" && git push && git push --tags",
     "major": "npm version major -m\"update version to %s\" && git push && git push --tags",
     "buildwp": "webpack --config webpack-production.config.js --progress --profile --colors",
-    "babel": "rm -rf dist; babel src/ --out-dir dist/",
+    "babel": "rm -rf dist && babel src/ --out-dir dist/",
     "all": "npm run lint && npm run test && npm run babel"
   },
   "repository": {


### PR DESCRIPTION
changed `;` into `&&` for the `babel` script command of `packages.json`, to allow running the script under Windows environment. 