### PR TITLE
Support for custom delimiters (brackets)

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -71,6 +71,12 @@ $ rt <filename> [<filename> ...] [<args>]`,
         //enum: ['stylish', 'json'],
         description: 'Use a specific output format. (stylish|json)'
     }, {
+        option: 'brackets',
+        alias: 'b',
+        type: 'String',
+        default: '{ }',
+        description: 'Sets bracket delimiters for template expressions'
+    }, {
         option: 'target-version',
         alias: 't',
         type: 'String',

--- a/test/src/test.js
+++ b/test/src/test.js
@@ -251,12 +251,14 @@ test('test shell', function (t) {
 test('test convertText', function (t) {
     var texts = [
         {input: '{}', expected: '()'},
-        {input: "a {'b'}", expected: '"a "+(\'b\')'}
+        {input: "a {'b'}", expected: '"a "+(\'b\')'},
+        {input: "a {'{ b }'}", expected: '"a "+(\'{ b }\')'},
     ];
     t.plan(texts.length);
     texts.forEach(check);
     function check(testData) {
-        var r = reactTemplates._test.convertText({}, {}, testData.input);
+        var context = { options: { brackets: '{ }'} }; 
+        var r = reactTemplates._test.convertText({}, context, testData.input);
         t.equal(r, testData.expected);
     }
 });


### PR DESCRIPTION
Added support for customizable delimiters (brackets) e.g. `{{ }}`, `{% %}` etc.. in expressions.

There's a new option `-b` on the command line (which of course it defaults to `{ }`), e.g:
```
rt *.rt -b "{{ }}"
```

The change is mostly on the function `convertText()`. I would like to further improve it, making it recognize single and double quotes, like in:
```
<div>{'{'} and {"}"}</div>  
```

P.S. with 0.4.0 linter is more tolerant than before, is that intentional?