### PR TITLE
rt-virtual tag

### DIFF
--- a/src/reactTemplates.js
+++ b/src/reactTemplates.js
@@ -378,6 +378,7 @@ function convertHtmlToReact(node, context) {
             var code = convertHtmlToReact(child, context);
             validateJS(code, child, context);
             return code;
+        });    
 
         data.children = utils.concatChildren(children);
 

--- a/src/reactTemplates.js
+++ b/src/reactTemplates.js
@@ -51,6 +51,7 @@ var classAttr = 'class';
 var scopeAttr = 'rt-scope';
 var propsAttr = 'rt-props';
 var templateNode = 'rt-template';
+var virtualNode = 'rt-virtual';
 
 /**
  * @param {Options} options
@@ -378,13 +379,12 @@ function convertHtmlToReact(node, context) {
             var code = convertHtmlToReact(child, context);
             validateJS(code, child, context);
             return code;
-        });    
+        });
 
         data.children = utils.concatChildren(children);
 
-        if (node.name === 'virtual') {
+        if (node.name === virtualNode) { //eslint-disable-line wix-editor/prefer-ternary
             data.body = "[" + _.compact(children).join(',') + "]"
-            console.log(data.body)
         }
         else {
             data.body = _.template(getTagTemplateString(!hasNonSimpleChildren(node), reactSupport.shouldUseCreateElement(context)))(data);
@@ -530,6 +530,8 @@ function convertRT(html, reportContext, options) {
     });
     if (firstTag === null) {
         throw RTCodeError.build(context, rootNode.root()[0], 'Document should have a single root element');
+    } else if (firstTag.name === virtualNode) {
+        throw RTCodeError.build(context, firstTag, `Document should not have <${virtualNode}> as root element`);
     }
     var body = convertHtmlToReact(firstTag, context);
     var requirePaths = _(defines)

--- a/src/reactTemplates.js
+++ b/src/reactTemplates.js
@@ -374,13 +374,20 @@ function convertHtmlToReact(node, context) {
             }
         }
 
-        data.children = utils.concatChildren(_.map(node.children, function (child) {
+        var children = _.map(node.children, function (child) {
             var code = convertHtmlToReact(child, context);
             validateJS(code, child, context);
             return code;
-        }));
 
-        data.body = _.template(getTagTemplateString(!hasNonSimpleChildren(node), reactSupport.shouldUseCreateElement(context)))(data);
+        data.children = utils.concatChildren(children);
+
+        if (node.name === 'virtual') {
+            data.body = "[" + _.compact(children).join(',') + "]"
+            console.log(data.body)
+        }
+        else {
+            data.body = _.template(getTagTemplateString(!hasNonSimpleChildren(node), reactSupport.shouldUseCreateElement(context)))(data);
+        }
 
         if (node.attribs[scopeAttr]) {
             var functionBody = _.values(data.innerScope.innerMapping).join('\n') + `return ${data.body}`;

--- a/test/data/invalid-virtual.rt
+++ b/test/data/invalid-virtual.rt
@@ -1,0 +1,3 @@
+<rt-virtual>
+   <div>This is not allowed</div>
+</rt-virtual>

--- a/test/data/virtual.rt
+++ b/test/data/virtual.rt
@@ -1,0 +1,14 @@
+<div>
+  <rt-virtual rt-scope="'rendered' as verb">
+    <rt-virtual rt-if="1<0">
+        <div>this is not {verb}</div>
+    </rt-virtual>
+    <rt-virtual rt-if="1>0">
+        <div>this is {verb}</div>
+    </rt-virtual>
+    <rt-virtual rt-repeat="n in [1,2]">
+        <div>{verb} {n}-a</div>
+        <div>{verb} {n}-b</div>
+    </rt-virtual>
+  </rt-virtual>
+</div>

--- a/test/data/virtual.rt.html
+++ b/test/data/virtual.rt.html
@@ -1,0 +1,1 @@
+<div><div>this is rendered</div><div>rendered 1-a</div><div>rendered 1-b</div><div>rendered 2-a</div><div>rendered 2-b</div></div>

--- a/test/src/test.js
+++ b/test/src/test.js
@@ -26,7 +26,8 @@ var invalidFiles = [
     {file: 'invalid-repeat.rt', issue: new RTCodeError('rt-repeat invalid \'in\' expression \'a in b in c\'', 0, 35, 1, 1)},
     {file: 'invalid-rt-require.rt', issue: new RTCodeError("rt-require needs 'dependency' and 'as' attributes", 0, 14, 1, 1)},
     {file: 'invalid-brace.rt', issue: new RTCodeError('Unexpected end of input', 128, 163, 5, 11)},
-    {file: 'invalid-style.rt', issue: new RTCodeError('Unexpected token ILLEGAL', 10, 39, 2, 5)}
+    {file: 'invalid-style.rt', issue: new RTCodeError('Unexpected token ILLEGAL', 10, 39, 2, 5)},
+    {file: 'invalid-virtual.rt', issue: new RTCodeError('Document should not have <rt-virtual> as root element', 0, 60, 1, 1)}
 ];
 
 test('invalid tests', function (t) {
@@ -183,7 +184,7 @@ test('convert jsrt and test source results', function (t) {
 
 test('html tests', function (t) {
     var files = ['scope.rt', 'scope-trailing-semicolon.rt', 'scope-variable-references.rt', 'lambda.rt', 'eval.rt', 'props.rt', 'custom-element.rt', 'style.rt', 'concat.rt',
-                 'js-in-attr.rt', 'props-class.rt', 'rt-class.rt', 'className.rt', 'svg.rt',
+                 'js-in-attr.rt', 'props-class.rt', 'rt-class.rt', 'className.rt', 'svg.rt', 'virtual.rt',
                  'scope-evaluated-after-repeat.rt', 'scope-evaluated-after-repeat2.rt', 'scope-evaluated-after-if.rt', 'scope-obj.rt'
     ];
     t.plan(files.length);


### PR DESCRIPTION
This creates support for a `<rt-virtual>` tag whose root won't be rendered on the DOM.

Meant to be used with `rt-if`, `rt-repeat`, etc... An example:
```HTML
<ul>
  <rt-virtual rt-repeat="n in [1,2,3]">
    <li>{n}</li>
    <li>{n*2}</li>
  </virtual>
</ul>
```
generates
```HTML
<ul>
  <li>1</li>
  <li>2</li>
  <li>2</li>
  <li>4</li>
  <li>3</li>
  <li>6</li>
</ul>
```
