### PR TITLE
Correctly parse rt-repeat object literal collection

### DIFF
--- a/src/reactTemplates.js
+++ b/src/reactTemplates.js
@@ -346,7 +346,7 @@ function convertHtmlToReact(node, context) {
             data.item = arr[0].trim();
             data.collection = arr[1].trim();
             validateJS(data.item, node, context);
-            validateJS(data.collection, node, context);
+            validateJS("(" + data.collection + ")", node, context);
             stringUtils.addIfMissing(context.boundParams, data.item);
             stringUtils.addIfMissing(context.boundParams, `${data.item}Index`);
         }

--- a/test/data/repeat-literal-collection.rt
+++ b/test/data/repeat-literal-collection.rt
@@ -1,0 +1,5 @@
+<div>
+  <div rt-repeat="items in {a:1, b:2}">
+    {items}
+  </div>
+</div>

--- a/test/data/repeat-literal-collection.rt.html
+++ b/test/data/repeat-literal-collection.rt.html
@@ -1,0 +1,1 @@
+<div><div>1</div><div>2</div></div>

--- a/test/src/test.js
+++ b/test/src/test.js
@@ -184,7 +184,7 @@ test('convert jsrt and test source results', function (t) {
 test('html tests', function (t) {
     var files = ['scope.rt', 'scope-trailing-semicolon.rt', 'scope-variable-references.rt', 'lambda.rt', 'eval.rt', 'props.rt', 'custom-element.rt', 'style.rt', 'concat.rt',
                  'js-in-attr.rt', 'props-class.rt', 'rt-class.rt', 'className.rt', 'svg.rt',
-                 'scope-evaluated-after-repeat.rt', 'scope-evaluated-after-repeat2.rt', 'scope-evaluated-after-if.rt', 'scope-obj.rt'
+                 'repeat-literal-collection.rt', 'scope-evaluated-after-repeat.rt', 'scope-evaluated-after-repeat2.rt', 'scope-evaluated-after-if.rt', 'scope-obj.rt'
     ];
     t.plan(files.length);
 


### PR DESCRIPTION
This fixes a small glitch that caused the following template to not be parsed.
```
 <div rt-repeat="v in {a:1, b:2}">
```
The problem was caused by the object literal expression `{a:1, b:2}` being interpreted as a statement by `esprima.parse()`. 

I've fixed it simply by wrapping the collection argument around `(` `)` during the check. 

