### PR TITLE
esprima-fb deprecated, back to upstream/esprima

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "chalk": "^1.1.1",
     "cheerio": "^0.19.0",
     "css": "^2.2.1",
-    "escodegen": "1.7.1",
+    "escodegen": "^1.8.0",
     "esprima": "^2.7.1",
     "lodash": "^3.10.1",
     "optionator": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "cheerio": "^0.19.0",
     "css": "^2.2.1",
     "escodegen": "1.7.1",
-    "esprima-fb": "^15001.1001.0-dev-harmony-fb",
+    "esprima": "^2.7.1",
     "lodash": "^3.10.1",
     "optionator": "^0.8.0",
     "text-table": "^0.2.0"

--- a/src/reactTemplates.js
+++ b/src/reactTemplates.js
@@ -1,7 +1,7 @@
 'use strict';
 var cheerio = require('cheerio');
 var _ = require('lodash');
-var esprima = require('esprima-fb');
+var esprima = require('esprima');
 var escodegen = require('escodegen');
 var reactDOMSupport = require('./reactDOMSupport');
 var reactNativeSupport = require('./reactNativeSupport');

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 'use strict';
 var _ = require('lodash');
-var esprima = require('esprima-fb');
+var esprima = require('esprima');
 var rtError = require('./RTCodeError');
 var RTCodeError = rtError.RTCodeError;
 

--- a/test/data/div.rt.es6.js
+++ b/test/data/div.rt.es6.js
@@ -2,4 +2,4 @@ import React from 'react/addons';
 import _ from 'lodash';
 export default function () {
     return React.createElement('div', {});
-};
+}


### PR DESCRIPTION
As `esprima-fb` was deprecated, this PR switches back to the upstream `jquery/esprima` as suggested by the maintainers:

> ... we no longer have a need to maintain our Esprima fork (esprima-fb). The upstream Esprima and other esprima-based forks, like Espree, have been doing an excellent job of supporting new language features recently. If you have a need of an esprima-based parser, we encourage you to look into using one of those.

If my understanding is correct, `react-templates` uses `esprima-fb` only for `validateJS()` where no JSX is needed, so the switch shouldn't cause problems.

To make this switch possible, a [bug in escodegen](https://github.com/estools/escodegen/issues/278) had to be fixed first, but luckily they did it very quickly.
