### PR TITLE
provide a key to virtual node children

### DIFF
--- a/src/reactTemplates.js
+++ b/src/reactTemplates.js
@@ -375,6 +375,21 @@ function convertHtmlToReact(node, context) {
             }
         }
 
+        // provide a key to virtual node children if missing
+        if (node.name === virtualNode) {
+           if (node.children.length > 1) {
+              var keyCounter = 0;
+              _.forEach(node.children, function(child) {
+                 if (!child.attribs) {
+                    child.attribs = {};
+                 }
+                 if (!child.attribs["key"]) {
+                    child.attribs["key"] = String(node.startIndex + keyCounter++);
+                 }
+              });
+           }
+        }
+
         var children = _.map(node.children, function (child) {
             var code = convertHtmlToReact(child, context);
             validateJS(code, child, context);


### PR DESCRIPTION
This PR makes direct children of a `<rt-virtual>` tag have an unique key.

Having a key is necessary because `<rt-virtual>` children are mapped to an array.

The key:
- is generated combining a counter + offset of the tag in the original `.rt` file
- is applied only if there are at least two children (with one, the default key is enough)
- is applied only if not explicitly defined
