### PR TITLE
Template causes React Native packager to break

### DIFF
--- a/src/reactTemplates.js
+++ b/src/reactTemplates.js
@@ -566,9 +566,9 @@ function convertRT(html, reportContext, options) {
         .join(',');
     var buildImport;
     if (options.modules === 'typescript') {
-        buildImport = (v, p) => `import ${v} = require('${p}');`;
+        buildImport = (v, p) => `import ${v}` + ` = require('${p}');`;
     } else if (options.modules === 'es6') { // eslint-disable-line
-        buildImport = (v, p) => `import ${v} from '${p}';`;
+        buildImport = (v, p) => `import ${v}` + ` from '${p}';`;
     } else {
         buildImport = (v, p) => `var ${v} = require('${p}');`;
     }


### PR DESCRIPTION
It seems that the React Native packager has problems with the following string:
`import ${v} from '${p}';`

I already reported this in the React Native repository:
https://github.com/facebook/react-native/issues/6323