### PR TITLE
fixed rt-class to also work with lodash 4.5.0

### DIFF
--- a/src/reactTemplates.js
+++ b/src/reactTemplates.js
@@ -32,7 +32,7 @@ const propsMergeFunction = `function mergeProps(inline,external) {
 }
 `
 
-var classSetTemplate = _.template('_.keys(_.pick(<%= classSet %>, _.identity)).join(" ")');
+var classSetTemplate = _.template('_(<%= classSet %>).transform(function(res, value, key){ if(value){ res.push(key); } }, []).value().join(" ")');
 
 function getTagTemplateString(simpleTagTemplate, shouldCreateElement) {
     if (simpleTagTemplate) {


### PR DESCRIPTION
Fixed rt-class so it won't depend on _.pick which was changed in lodash 4.5.0 and now works differently than in 3.10.0

Related issue:
https://github.com/wix/react-templates/issues/105