### PR TITLE
Support for stateless components

### DIFF
--- a/src/reactSupport.js
+++ b/src/reactSupport.js
@@ -35,16 +35,16 @@ _.forEach(reactSupportedAttributes, attributeReactName => {
 const htmlSelfClosingTags = ['area', 'base', 'br', 'col', 'command', 'embed', 'hr', 'img', 'input', 'keygen', 'link', 'meta', 'param', 'source', 'track', 'wbr'];
 
 
-const templateAMDTemplate = _.template("define(<%= name ? '\"'+name + '\", ' : '' %>[<%= requirePaths %>], function (<%= requireNames %>) {\n'use strict';\n <%= injectedFunctions %>\nreturn function(){ return <%= body %>};\n});");
-const templateCommonJSTemplate = _.template("'use strict';\n<%= vars %>\n\n<%= injectedFunctions %>\nmodule.exports = function(){ return <%= body %>};\n");
-const templateES6Template = _.template('<%= vars %>\n\n<%= injectedFunctions %>\nexport default function(){ return <%= body %>}\n');
-const templatePJSTemplate = _.template(`var <%= name %> = function () {
+const templateAMDTemplate = _.template("define(<%= name ? '\"'+name + '\", ' : '' %>[<%= requirePaths %>], function (<%= requireNames %>) {\n'use strict';\n <%= injectedFunctions %>\nreturn function(<%= renderArguments %>){ return <%= body %>};\n});");
+const templateCommonJSTemplate = _.template("'use strict';\n<%= vars %>\n\n<%= injectedFunctions %>\nmodule.exports = function(<%= renderArguments %>){ return <%= body %>};\n");
+const templateES6Template = _.template('<%= vars %>\n\n<%= injectedFunctions %>\nexport default function(<%= renderArguments %>){ return <%= body %>}\n');
+const templatePJSTemplate = _.template(`var <%= name %> = function (<%= renderArguments %>) {
 <%= injectedFunctions %>
 return <%= body %>
 };
 `);
-const templateTypescriptTemplate = _.template('<%= vars %>\n\n<%= injectedFunctions %>\nvar fn = function() { return <%= body %> };\nexport = fn\n');
-const templateJSRTTemplate = _.template('(function () {\n <%= injectedFunctions %>\n return function(){\nreturn <%= body %>}}\n)()');
+const templateTypescriptTemplate = _.template('<%= vars %>\n\n<%= injectedFunctions %>\nvar fn = function(<%= renderArguments %>) { return <%= body %> };\nexport = fn\n');
+const templateJSRTTemplate = _.template('(function () {\n <%= injectedFunctions %>\n return function(<%= renderArguments %>){\nreturn <%= body %>}}\n)()');
 
 const templates = {
     amd: templateAMDTemplate,

--- a/test/data/invalid/invalid-rt-stateless.rt
+++ b/test/data/invalid/invalid-rt-stateless.rt
@@ -1,0 +1,5 @@
+<rt-stateless>
+   42
+</rt-stateless>
+<div>
+</div>

--- a/test/data/stateless.rt
+++ b/test/data/stateless.rt
@@ -1,0 +1,4 @@
+<rt-stateless />
+<div>
+   This is a stateless component showing {props.someProp} and {context.someContextData}
+</div>

--- a/test/data/stateless.rt.js
+++ b/test/data/stateless.rt.js
@@ -1,0 +1,9 @@
+define([
+    'react/addons',
+    'lodash'
+], function (React, _) {
+    'use strict';
+    return function (props, context) {
+        return React.createElement('div', {}, '\n   This is a stateless component showing ', props.someProp, ' and ', context.someContextData, '\n');
+    };
+});

--- a/test/src/rt.invalid.spec.js
+++ b/test/src/rt.invalid.spec.js
@@ -30,7 +30,8 @@ module.exports = {
             {file: 'invalid-rt-import-3.rt', issue: new RTCodeError("'rt-import' needs 'name' and 'from' attributes", 0, 13, 1, 1)},
             {file: 'invalid-brace.rt', issue: new RTCodeError('Unexpected end of input', 128, 163, 5, 11)},
             {file: 'invalid-style.rt', issue: new RTCodeError('Unexpected token ILLEGAL', 10, 39, 2, 5)},
-            {file: 'invalid-virtual.rt', issue: new RTCodeError('Document should not have <rt-virtual> as root element', 0, 60, 1, 1)}
+            {file: 'invalid-virtual.rt', issue: new RTCodeError('Document should not have <rt-virtual> as root element', 0, 60, 1, 1)},
+            {file: 'invalid-rt-stateless.rt', issue: new RTCodeError("'rt-stateless' may have no children", 0, 36, 1, 1)}
         ];
 
         test('invalid tests', t => {

--- a/test/src/rt.valid.spec.js
+++ b/test/src/rt.valid.spec.js
@@ -29,7 +29,7 @@ module.exports = {
         });
 
         test('conversion test', t => {
-            const files = ['div.rt', 'test.rt', 'repeat.rt', 'inputs.rt', 'virtual.rt'];
+            const files = ['div.rt', 'test.rt', 'repeat.rt', 'inputs.rt', 'virtual.rt', 'stateless.rt'];
             testFiles(t, files);
         });
 


### PR DESCRIPTION
This PR allows to emit a pure stateless function (see [here](https://facebook.github.io/react/docs/reusable-components.html#stateless-functions)) by placing the special tag `<rt-stateless />` in the .rt file.

Example:
```HTML
<rt-stateless />
<div>
   This is a stateless component showing {props.someProp} and {context.someContextData}
</div>
```
The difference is only in the signature of the emitted render function:
```js
function (props, context) { ... }
```
instead of
```js
function () { ... }
```