### PR TITLE
updated Playground (fixes #140)

### DIFF
--- a/home.config.js
+++ b/home.config.js
@@ -8,7 +8,8 @@
         lodash: '//cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.1/lodash',
         jquery: '//code.jquery.com/jquery-1.11.0.min',
         firebase: '//cdn.firebase.com/js/client/2.0.5/firebase',
-        react: '//cdnjs.cloudflare.com/ajax/libs/react/0.13.3/react-with-addons',
+        react: '//cdnjs.cloudflare.com/ajax/libs/react/15.1.0/react-with-addons',
+        'react-dom': '//cdnjs.cloudflare.com/ajax/libs/react/15.1.0/react-dom',
         //ace: '../ace-builds-1.1.8/src-min/ace',
         fiddle: './fiddle',
         text: 'libs/requirejs-plugins/text',
@@ -18,7 +19,8 @@
         lodash: {exports: '_'},
         firebase: {exports: 'Firebase'},
         jquery: {exports: '$'},
-        react: {exports: 'React'}
+        react: {exports: 'React'},
+        'react-dom': {exports: 'ReactDOM'}
     },
     map: {
         '*': {

--- a/playground.config.js
+++ b/playground.config.js
@@ -7,7 +7,8 @@
         lodash: '//cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.1/lodash',
         jquery: '//code.jquery.com/jquery-2.1.4.min',
         firebase: '//cdn.firebase.com/js/client/2.0.5/firebase',
-        react: '//cdnjs.cloudflare.com/ajax/libs/react/0.13.3/react-with-addons',
+        react: '//cdnjs.cloudflare.com/ajax/libs/react/15.1.0/react-with-addons',
+        'react-dom': '//cdnjs.cloudflare.com/ajax/libs/react/15.1.0/react-dom',
         //ace: '../ace-builds-1.1.8/src-min/ace',
         fiddle: './fiddle',
         text: 'libs/requirejs-plugins/text',
@@ -18,7 +19,8 @@
         lodash: {exports: '_'},
         firebase: {exports: 'Firebase'},
         jquery: {exports: '$'},
-        react: {exports: 'React'}
+        react: {exports: 'React'},
+        'react-dom': {exports: 'ReactDOM'}
     },
     map: {
         '*': {

--- a/playground/CodeMirrorEditor.js
+++ b/playground/CodeMirrorEditor.js
@@ -1,4 +1,4 @@
-define(['react', 'lodash', 'jquery', './libs/codemirror-4.8/lib/codemirror',
+define(['react', 'react-dom', 'lodash', 'jquery', './libs/codemirror-4.8/lib/codemirror',
         './CMLint',
         './libs/codemirror-4.8/mode/javascript/javascript',
         './libs/codemirror-4.8/addon/hint/html-hint',
@@ -10,7 +10,7 @@ define(['react', 'lodash', 'jquery', './libs/codemirror-4.8/lib/codemirror',
         //'./libs/codemirror-4.8/mode/css/css',
         './libs/codemirror-4.8/addon/runmode/runmode'
         //'./libs/codemirror-4.8/addon/display/placeholder'
-], function (React, _, $, CodeMirror, CMLint) {
+], function (React, ReactDOM, _, $, CodeMirror, CMLint) {
     'use strict';
     //codeMirror: 'libs/codemirror-4.8/lib/codemirror',
     //htmlmixed: 'libs/codemirror-4.8/mode/htmlmixed/htmlmixed',
@@ -134,7 +134,7 @@ define(['react', 'lodash', 'jquery', './libs/codemirror-4.8/lib/codemirror',
                 //options.lint = true;
             }
 
-            this.editor = CodeMirror.fromTextArea(this.getDOMNode(), options);
+            this.editor = CodeMirror.fromTextArea(ReactDOM.findDOMNode(this), options);
 
             if (!this.props.readOnly) {
                 this.editor.on('change', function (/*e*/) {

--- a/playground/CodeMirrorViewer.js
+++ b/playground/CodeMirrorViewer.js
@@ -1,8 +1,8 @@
-define(['react', 'lodash', 'jquery', './libs/codemirror-4.8/lib/codemirror',
+define(['react', 'react-dom', 'lodash', 'jquery', './libs/codemirror-4.8/lib/codemirror',
         './libs/codemirror-4.8/mode/javascript/javascript',
         './libs/codemirror-4.8/mode/xml/xml',
         './libs/codemirror-4.8/addon/runmode/runmode'
-], function (React, _, $, CodeMirror) {
+], function (React, ReactDOM, _, $, CodeMirror) {
     'use strict';
     return React.createClass({
         displayName: 'CodeMirrorViewer',
@@ -37,7 +37,7 @@ define(['react', 'lodash', 'jquery', './libs/codemirror-4.8/lib/codemirror',
             if (this.props.mode === 'html') {
                 mode = 'text/html';
             }
-            this.editor = CodeMirror.runMode(value, mode, this.getDOMNode());
+            this.editor = CodeMirror.runMode(value, mode, ReactDOM.findDOMNode(this));
         },
         componentWillUnmount: function () {
             this.editor.toTextArea();

--- a/playground/fiddle-main.js
+++ b/playground/fiddle-main.js
@@ -3,7 +3,8 @@ requirejs.config({
         lodash: '//cdnjs.cloudflare.com/ajax/libs/lodash.js/3.10.0/lodash.min',
         jquery: '//code.jquery.com/jquery-2.1.4.min',
         firebase: '//cdn.firebase.com/js/client/2.0.5/firebase',
-        react: '//cdnjs.cloudflare.com/ajax/libs/react/0.13.3/react-with-addons',
+        react: '//cdnjs.cloudflare.com/ajax/libs/react/15.1.0/react-with-addons',
+        'react-dom': '//cdnjs.cloudflare.com/ajax/libs/react/15.1.0/react-dom',
         fiddle: './fiddle',
         text: 'libs/requirejs-plugins/text',
         json: 'libs/requirejs-plugins/json',
@@ -13,15 +14,16 @@ requirejs.config({
         lodash: {exports: '_'},
         firebase: {exports: 'Firebase'},
         jquery: {exports: '$'},
-        react: {exports: 'React'}
+        react: {exports: 'React'},
+        'react-dom': {exports: 'ReactDOM'}
     },
     map: {
         '*': {'react/addons': 'react'}
     }
 });
 
-requirejs(['fiddle', 'react', 'jquery', 'bootstrap'], function (fiddle, React) {
+requirejs(['fiddle', 'react', 'react-dom', 'jquery', 'bootstrap'], function (fiddle, React, ReactDOM) {
     'use strict';
     var elem = React.createElement(fiddle);
-    window.fiddle = React.render(elem, document.getElementById('container'));
+    window.fiddle = ReactDOM.render(elem, document.getElementById('container'));
 });

--- a/playground/home-main.js
+++ b/playground/home-main.js
@@ -5,7 +5,8 @@ requirejs.config({
         lodash: '//cdnjs.cloudflare.com/ajax/libs/lodash.js/3.10.0/lodash.min',
         jquery: '//code.jquery.com/jquery-2.1.4.min',
         firebase: 'https://cdn.firebase.com/js/client/2.0.5/firebase',
-        react: '//cdnjs.cloudflare.com/ajax/libs/react/0.13.3/react-with-addons',
+        react: '//cdnjs.cloudflare.com/ajax/libs/react/15.1.0/react-with-addons',
+        'react-dom': '//cdnjs.cloudflare.com/ajax/libs/react/15.1.0/react-dom',
         text: 'libs/requirejs-plugins/text',
         json: 'libs/requirejs-plugins/json'
         //examples: './examples'
@@ -14,15 +15,16 @@ requirejs.config({
         lodash: {exports: '_'},
         firebase: {exports: 'Firebase'},
         jquery: {exports: '$'},
-        react: {exports: 'React'}
+        react: {exports: 'React'},
+        'react-dom': {exports: 'ReactDOM'}
     },
     map: {
         '*': {'react/addons': 'react'}
     }
 });
 
-requirejs(['./examples', 'react', 'jquery'], function (Examples, React) {
+requirejs(['./examples', 'react', 'react-dom', 'jquery'], function (Examples, React, ReactDOM) {
     'use strict';
     var elem = React.createElement(Examples);
-    React.render(elem, document.getElementById('home-section'));
+    ReactDOM.render(elem, document.getElementById('home-section'));
 });

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -1,5 +1,5 @@
 /*eslint-env browser*/
-define(['react', 'jquery', 'lodash', './playground-fiddle.rt', './playground.rt'], function (React, $, _, pgFiddleTemplate, playgroundTemplate) {
+define(['react', 'react-dom', 'jquery', 'lodash', './playground-fiddle.rt', './playground.rt'], function (React, ReactDOM, $, _, pgFiddleTemplate, playgroundTemplate) {
     'use strict';
     //function emptyFunc() {
     //    return null;
@@ -171,20 +171,20 @@ define(['react', 'jquery', 'lodash', './playground-fiddle.rt', './playground.rt'
             //this.sample = React.createFactory(React.createClass(classBase));
         },
         showError: function (e, editor) {
-            var mountNode = this.refs.mount.getDOMNode();
+            var mountNode = this.refs.mount;
             this.setTimeout(function () {
                 showMessage(editor, e.message);
-                React.render(
+                ReactDOM.render(
                     React.createElement('div', {className: 'playground-error'}, e.toString()),
                     mountNode
                 );
             }, 500);
         },
         showErrorAnnotation: function (annot, editor) {
-            var mountNode = this.refs.mount.getDOMNode();
+            var mountNode = this.refs.mount;
             this.setTimeout(function () {
                 editor.annotate(annot);
-                React.render(
+                ReactDOM.render(
                     React.createElement('div', {className: 'playground-error'}, annot.message),
                     mountNode
                 );
@@ -233,9 +233,9 @@ define(['react', 'jquery', 'lodash', './playground-fiddle.rt', './playground.rt'
             this.renderSample();
         },
         renderSample: function () {
-            var mountNode = this.refs.mount.getDOMNode();
+            var mountNode = this.refs.mount;
             if (this.sample) {
-                React.render(this.sample, mountNode);
+                ReactDOM.render(this.sample, mountNode);
             }
         },
         componentDidUpdate: function () {


### PR DESCRIPTION
This PR updates the playground to React v15.1.0 (from v0.13.3).

The changes can be summarized as follows:
- split `react` into `react` and `react-dom`
- modified `refs.node.getDOMNode()` into `refs.node`
- modified `this.getDOMNode()` into `ReactDOM.findDOMNode(this)`
- modified `React.render()` into `ReactDOM.render()`


