### PR TITLE
implements #175, better rt-scope syntax parser

### DIFF
--- a/test/data/scope-reserved-tokens.rt
+++ b/test/data/scope-reserved-tokens.rt
@@ -1,0 +1,4 @@
+<div rt-scope="'as fast as possible' as message;';' as semicolon;'as' as as">
+	{message}{semicolon}{as}
+</div>
+

--- a/test/data/scope-reserved-tokens.rt.html
+++ b/test/data/scope-reserved-tokens.rt.html
@@ -1,0 +1,2 @@
+<div>as fast as possible;as</div>
+

--- a/test/src/rt-html-valid.spec.js
+++ b/test/src/rt-html-valid.spec.js
@@ -31,6 +31,7 @@ module.exports = {
                 'scope-evaluated-after-repeat2.rt',
                 'scope-evaluated-after-if.rt',
                 'scope-obj.rt',
+                'scope-reserved-tokens.rt',
                 'repeat-literal-collection.rt',
                 'include.rt'
             ];


### PR DESCRIPTION
This PR improves the parser for `rt-scope` as discussed in #175.

It's based on a regex, the improvement comes from scanning for ` as identifier;` instead of just `;` thus lowering the chances of picking a semicolon in the wrong place.

Of course there are still failing cases, but they are much less.

With this PR the following can be now parsed:
```html
<div rt-scope="'as fast as possible' as message;';' as semicolon;'as' as as">
	{message}{semicolon}{as}
</div>
```