### PR TITLE
Match any case for the "as" keyword.

### DIFF
--- a/src/reactTemplates.js
+++ b/src/reactTemplates.js
@@ -490,7 +490,7 @@ function parseScopeSyntax(text) {
     //
     // regex = capture(expression) + as + capture(id) + optional_spaces + semicolon + optional_spaces
 
-    const regex = RegExp("((?:(?:\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*\"|'[^'\\\\]*(?:\\\\.[^'\\\\]*)*'|[^\"']*?))*?) as(?: )+([$_a-zA-Z]+[$_a-zA-Z0-9]*)(?: )*(?:;|$)(?: )*", 'g')
+    const regex = RegExp("((?:(?:\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*\"|'[^'\\\\]*(?:\\\\.[^'\\\\]*)*'|[^\"']*?))*?) [Aa][Ss](?: )+([$_a-zA-Z]+[$_a-zA-Z0-9]*)(?: )*(?:;|$)(?: )*", 'g')
     const res = []
     do {
         const idx = regex.lastIndex


### PR DESCRIPTION
When using anything other than 'as' it was causing the parseScopeSyntax function to throw an exception. 

Among other things, this caused an issue with web pack setting in an infinite loops trying to compile.